### PR TITLE
Create a function for processing messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# mqp setup
+
+### Install rabbitmq
+
+    brew install rabbitmq
+
+    brew services start rabbitmq
+
+### create user and vhost
+
+    rabbitmqctl add_user mqp mqptest
+
+    rabbitmqctl add_vhost mqp
+
+    rabbitmqctl set_permissions --vhost mqp mqp ".*" ".*" ".*"

--- a/main.go
+++ b/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	// packages
+	//"fmt"
+	"github.com/streadway/amqp"
+	"log"
+	"time"
+	//"github.com/Hireology/go_shared/messaging"
+)
+
+var (
+	scheme   = "amqp"
+	user     = "mqp"
+	password = "mqptest"
+	host     = "127.0.0.1"
+	port     = 5672
+	//vhost    = "/"
+	vhost = "mqp"
+)
+
+func main() {
+	// stuff
+}
+
+func failOnError(prefix string, err error) {
+	if err != nil {
+		log.Fatalf("%s: %s", prefix, err)
+	}
+}
+
+func connect(connectionString string) (conn *amqp.Connection) {
+	conn, err := amqp.Dial(connectionString)
+	failOnError("connection failure", err)
+
+	return conn
+}
+
+/*
+// connect with tls
+func connectTLS() {
+}
+*/
+
+func newBasicPublishing(message string) *amqp.Publishing {
+	publishing := amqp.Publishing{
+		DeliveryMode: amqp.Transient,
+		Timestamp:    time.Now(),
+		ContentType:  "text/plain",
+		Body:         []byte(message),
+	}
+	return &publishing
+}
+
+// publish a message
+func publishMessage(c *amqp.Channel, message string) amqp.Publishing {
+	exchange := ""
+	routingKey := "myRoutingKey"
+	publishing := newBasicPublishing(message)
+
+	q, err := c.QueueDeclare(routingKey, false, true, true, true, nil)
+	failOnError("queue declare", err)
+	err = c.Publish(exchange, q.Name, true, false, *publishing)
+	// TODO where does this prefix come from?
+	failOnError("basic.publish", err)
+	defer c.Close()
+	return *publishing
+}
+
+// consume a message
+func consumeMessage(c *amqp.Channel, queue, consumer string) amqp.Delivery {
+	//func (ch *Channel) Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args Table) (<-chan Delivery, error)
+	deliver, err := c.Consume(queue, consumer, false, false, false, false, nil)
+	failOnError("channel.consume", err)
+	// what should this actually return?
+	// what do we get from <-chan amqp.Deliver ?
+	for {
+		msg, ok := <-deliver
+		if ok == false {
+			log.Println("channel closed")
+			break
+		}
+		log.Println("received:", msg, ok)
+		err := msg.Ack(true)
+		failOnError("delivery.ack", err)
+	}
+
+	stuff := amqp.Delivery{}
+	return stuff
+}

--- a/main.go
+++ b/main.go
@@ -75,7 +75,6 @@ func messages(c *amqp.Channel, queue, consumer string) <-chan amqp.Delivery {
 		false, // noWait
 		nil,   // args
 	)
-	//c.Close()
 	failOnError("channel.consume", err)
 	return deliver
 }

--- a/main_test.go
+++ b/main_test.go
@@ -46,6 +46,9 @@ func TestPublishMessage(t *testing.T) {
 	conn := connect(connectionString)
 	channel, err := conn.Channel()
 	failOnError("channel.open", err)
+	rk := "myRoutingKey"
+	_, err = channel.QueueDeclare(rk, false, true, true, true, nil)
+	failOnError("queue.declare", err)
 	publishMessage(channel, "hello world")
 
 	// got should be the last message in whatever test queue we used
@@ -66,11 +69,15 @@ func TestConsumeMessage(t *testing.T) {
 	conn := connect(connectionString)
 	channel, err := conn.Channel()
 	failOnError("channel.open", err)
+	rk := "myRoutingKey"
+	_, err = channel.QueueDeclare(rk, false, true, true, true, nil)
+	failOnError("queue.declare", err)
 	publishMessage(channel, "ping")
 
 	// then consume
 	// FIXME the channel never seems to close
-	consumeMessage(channel, "myRoutingKey", "myConsumer")
+	messages := messages(channel, rk, "myConsumer")
+	processMessages(messages)
 
 	got := "foo"
 	want := "bar"

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	//"log"
+	"testing"
+)
+
+// test BEHAVIOR not implementation
+
+/*
+func TestMain(t *testing.T) {
+    got := "foo"
+    want := "bar"
+    if got != want {
+        t.Errorf("got %s; want %s", got, want)
+    }
+}
+*/
+
+func TestConnect(t *testing.T) {
+	connectionString := fmt.Sprintf("%s://%s:%s@%s:%d/%s",
+		scheme, user, password, host, port, vhost)
+	conn := connect(connectionString)
+	got := fmt.Sprintf("%s", conn.Config.Vhost)
+	//got := fmt.Sprintf("%+v", conn)
+	want := vhost
+	if got != want {
+		t.Errorf("got %s; want %s", got, want)
+	}
+	defer conn.Close()
+}
+
+func TestNewBasicPublishing(t *testing.T) {
+	pub := newBasicPublishing("hello world")
+	got := string(pub.Body[:])
+	want := "hello world"
+	if got != want {
+		t.Errorf("got %s; want %s", got, want)
+	}
+}
+
+func TestPublishMessage(t *testing.T) {
+	connectionString := fmt.Sprintf("%s://%s:%s@%s:%d/%s",
+		scheme, user, password, host, port, vhost)
+	conn := connect(connectionString)
+	channel, err := conn.Channel()
+	failOnError("channel.open", err)
+	publishMessage(channel, "hello world")
+
+	// got should be the last message in whatever test queue we used
+	msg, _, err := channel.Get("myRoutingKey", false)
+	failOnError("channel.get", err)
+	got := string(msg.Body[:])
+	want := "hello world"
+	if got != want {
+		t.Errorf("got %s; want %s", got, want)
+	}
+	defer conn.Close()
+}
+
+func TestConsumeMessage(t *testing.T) {
+	// publish a message
+	connectionString := fmt.Sprintf("%s://%s:%s@%s:%d/%s",
+		scheme, user, password, host, port, vhost)
+	conn := connect(connectionString)
+	channel, err := conn.Channel()
+	failOnError("channel.open", err)
+	publishMessage(channel, "ping")
+
+	// then consume
+	// FIXME the channel never seems to close
+	consumeMessage(channel, "myRoutingKey", "myConsumer")
+
+	got := "foo"
+	want := "bar"
+	if got != want {
+		t.Errorf("got %s; want %s", got, want)
+	}
+}
+
+/*
+func TestConnectTLS(t *testing.T) {
+    got := "foo"
+    want := "bar"
+    if got != want {
+        t.Errorf("got %s; want %s", got, want)
+    }
+}
+*/


### PR DESCRIPTION
This is the first pass at a utility for programmatically testing a RabbitMQ message broker pipeline.

- [x] Connects with AMQP broker using [RFC3986](https://www.ietf.org/rfc/rfc3986.txt) URIs
- [x] Publish a message to the default exchange
- [x] Consume a message

Known issue: When running tests, the connection on which messages are published seems to remain open, and I can't figure out why.