### PR TITLE
[SYS-678]: Allow user to provide connection parameters

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	// packages
+	"flag"
 	//"fmt"
 	"github.com/streadway/amqp"
 	"log"
@@ -9,18 +10,58 @@ import (
 	//"github.com/Hireology/go_shared/messaging"
 )
 
+/*
 var (
 	scheme   = "amqp"
 	user     = "mqp"
 	password = "mqptest"
 	host     = "127.0.0.1"
 	port     = 5672
-	//vhost    = "/"
-	vhost = "mqp"
+	vhost    = "mqp" // leading slash is not needed
 )
+*/
+
+const (
+	DefaultScheme   = "amqp"
+	DefaultUser     = "mqp"
+	DefaultPassword = "mqptest"
+	DefaultHost     = "127.0.0.1"
+	DefaultPort     = 5672
+	DefaultVhost    = "mqp"
+)
+
+// TODO when to create one of these?
+// TODO do we actually connect when the object is created or just have an empty ref?
+type MQ struct {
+	URI        *amqp.URI
+	Connection *amqp.Connection
+}
+
+// NewMQ initializes RabbitMQ and returns a pointer to it
+func NewMQ(uri *amqp.URI) (*MQ, error) {
+	mq := MQ{
+		URI: uri,
+	}
+	err := mq.connect()
+	return &mq, err
+}
 
 func main() {
 	// stuff
+}
+
+func parseFlags() *amqp.URI {
+	// TODO flags won't always just be URI parameters
+	var uri = amqp.URI{
+		Scheme:   *flag.String("scheme", DefaultScheme, "Connection scheme"),
+		Host:     *flag.String("host", DefaultHost, "Connection host"),
+		Port:     *flag.Int("port", DefaultPort, "Connection port"),
+		Username: *flag.String("user", DefaultUser, "Connection user"),
+		Password: *flag.String("password", DefaultPassword, "Connection password"),
+		Vhost:    *flag.String("vhost", DefaultVhost, "Connection vhost"),
+	}
+	flag.Parse()
+	return &uri
 }
 
 func failOnError(prefix string, err error) {
@@ -29,11 +70,12 @@ func failOnError(prefix string, err error) {
 	}
 }
 
-func connect(connectionString string) (conn *amqp.Connection) {
-	conn, err := amqp.Dial(connectionString)
-	failOnError("connection failure", err)
+func (mq *MQ) connect() error {
+	conn, err := amqp.Dial(mq.URI.String())
+	//failOnError("connection failure", err)
+	mq.Connection = conn
 
-	return conn
+	return err
 }
 
 /*

--- a/main.go
+++ b/main.go
@@ -1,25 +1,11 @@
 package main
 
 import (
-	// packages
 	"flag"
-	//"fmt"
 	"github.com/streadway/amqp"
 	"log"
 	"time"
-	//"github.com/Hireology/go_shared/messaging"
 )
-
-/*
-var (
-	scheme   = "amqp"
-	user     = "mqp"
-	password = "mqptest"
-	host     = "127.0.0.1"
-	port     = 5672
-	vhost    = "mqp" // leading slash is not needed
-)
-*/
 
 const (
 	DefaultScheme   = "amqp"
@@ -72,7 +58,6 @@ func failOnError(prefix string, err error) {
 
 func (mq *MQ) connect() error {
 	conn, err := amqp.Dial(mq.URI.String())
-	//failOnError("connection failure", err)
 	mq.Connection = conn
 
 	return err
@@ -101,9 +86,7 @@ func publishMessage(c *amqp.Channel, message string) amqp.Publishing {
 	publishing := newBasicPublishing(message)
 
 	err := c.Publish(exchange, routingKey, true, false, *publishing)
-	// TODO where does this prefix come from?
 	failOnError("basic.publish", err)
-	//defer c.Close()
 	return *publishing
 }
 

--- a/main.go
+++ b/main.go
@@ -121,6 +121,7 @@ func messages(c *amqp.Channel, queue, consumer string) <-chan amqp.Delivery {
 	return deliver
 }
 
+// tell processMessages about how many messages it should get?
 func processMessages(messages <-chan amqp.Delivery) {
 	for d := range messages {
 		log.Println("received:", string(d.Body))

--- a/main_test.go
+++ b/main_test.go
@@ -31,7 +31,7 @@ func (suite *MQPTestSuite) TestConnect() {
 		- rmq not running
 	*/
 	conn := suite.mq.Connection
-	assert.Equal(suite.T(), conn.Config.Vhost, "mqp")
+	assert.Equal(suite.T(), "mqp", conn.Config.Vhost)
 	//defer conn.Close()
 }
 
@@ -43,7 +43,7 @@ func (suite *MQPTestSuite) TestNewBasicPublishing() {
 	   - emoji string
 	*/
 	pub := newBasicPublishing("hello world")
-	assert.Equal(suite.T(), string(pub.Body), "hello world")
+	assert.Equal(suite.T(), "hello world", string(pub.Body))
 }
 
 func (suite *MQPTestSuite) TestPublishMessage() {
@@ -65,7 +65,7 @@ func (suite *MQPTestSuite) TestPublishMessage() {
 	// got should be the last message in whatever test queue we used
 	msg, _, err := channel.Get(routingKey, false)
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), string(msg.Body), "hello world")
+	assert.Equal(suite.T(), "hello world", string(msg.Body))
 	defer conn.Close()
 }
 
@@ -100,7 +100,7 @@ func (suite *MQPTestSuite) TestProcessMessages() {
 func (suite *MQPTestSuite) TestParseFlags() {
 	got := suite.mq.URI.String()
 	want := "amqp://mqp:mqptest@127.0.0.1/mqp"
-	assert.Equal(suite.T(), got, want)
+	assert.Equal(suite.T(), want, got)
 }
 
 /*

--- a/main_test.go
+++ b/main_test.go
@@ -19,6 +19,10 @@ func (suite *MQPTestSuite) SetupSuite() {
 	assert.Nil(suite.T(), err)
 }
 
+func (suite *MQPTestSuite) TearDownSuite() {
+	suite.mq.Connection.Close()
+}
+
 func TestMQPTestSuite(t *testing.T) {
 	suite.Run(t, new(MQPTestSuite))
 }
@@ -32,7 +36,6 @@ func (suite *MQPTestSuite) TestConnect() {
 	*/
 	conn := suite.mq.Connection
 	assert.Equal(suite.T(), "mqp", conn.Config.Vhost)
-	//defer conn.Close()
 }
 
 func (suite *MQPTestSuite) TestNewBasicPublishing() {
@@ -52,7 +55,6 @@ func (suite *MQPTestSuite) TestPublishMessage() {
 	   - basic known good single message
 	   - multiple messages
 	*/
-	//conn := setup()
 	conn := suite.mq.Connection
 	channel, err := conn.Channel()
 	assert.Nil(suite.T(), err)
@@ -66,11 +68,9 @@ func (suite *MQPTestSuite) TestPublishMessage() {
 	msg, _, err := channel.Get(routingKey, false)
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), "hello world", string(msg.Body))
-	defer conn.Close()
 }
 
 func (suite *MQPTestSuite) TestProcessMessages() {
-	//suite.T().Skip("pls fix me")
 	/*
 	   cases:
 	   - one message


### PR DESCRIPTION
Users may now provide `--scheme`, `--host`, `--port`, `--username`, `--password`, and `--vhost` parameters at the command line.